### PR TITLE
Fixed template render error in ingress.yaml

### DIFF
--- a/qamatic/pact-broker/templates/_helpers.tpl
+++ b/qamatic/pact-broker/templates/_helpers.tpl
@@ -33,3 +33,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "pact-broker.labels" -}}
+app.kubernetes.io/name: {{ include "name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}


### PR DESCRIPTION
An error stating `[ERROR] templates/: render error in "pact-broker/templates/ingress.yaml": template: pact-broker/templates/ingress.yaml:8:3: executing "pact-broker/templates/ingress.yaml" at <include "pact-broker.labels" .>: error calling include: template: no template "pact-broker.labels" associated with template "gotpl"` is displayed when ingress is enabled. Added a definition for labels to fix this error. Also, added a couple of labels.